### PR TITLE
Handle LLM request failures

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,17 @@
+import unittest
+from unittest.mock import patch
+import requests
+
+from main import ask_llm, LLMServerUnavailable
+
+
+class AskLLMTests(unittest.TestCase):
+    @patch('requests.post')
+    def test_connection_error_raises(self, mock_post):
+        mock_post.side_effect = requests.exceptions.ConnectionError
+        with self.assertRaises(LLMServerUnavailable):
+            ask_llm('hi')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- wrap `requests.post` with error handling
- add retry/quit prompt when server is unavailable
- unit test for connection error using mocked requests

## Testing
- `python -m unittest discover -s tests -v`