### PR TITLE
Improve error detection logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -83,19 +83,19 @@ def run_command(cmd):
     return out, err
 
 def check_command_error(err):
+    lower_err = err.lower()
     error_signatures = [
-        "Syntax error",
         "syntax error",
-        "unexpected EOF",
+        "unexpected eof",
         "unterminated quoted string",
         "unmatched quote",
         "command not found",
         "not found",
         "invalid option",
-        "No such file or directory",
+        "no such file or directory",
     ]
     for sign in error_signatures:
-        if sign in err:
+        if sign in lower_err:
             return True
 
     return False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,15 +2,23 @@ import unittest
 from unittest.mock import patch
 import requests
 
-from main import ask_llm, LLMServerUnavailable
+import main
+from main import ask_llm, LLMServerUnavailable, check_command_error
 
 
 class AskLLMTests(unittest.TestCase):
     @patch('requests.post')
     def test_connection_error_raises(self, mock_post):
         mock_post.side_effect = requests.exceptions.ConnectionError
+        main.server_url = 'http://localhost'
+        main.model = 'test-model'
         with self.assertRaises(LLMServerUnavailable):
             ask_llm('hi')
+
+
+class CheckCommandErrorTests(unittest.TestCase):
+    def test_case_insensitive(self):
+        self.assertTrue(check_command_error('SyNtAx ErRoR somewhere'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- normalize stderr before checking for error keywords
- update error signatures
- tweak unit tests and add a case-insensitive check

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_688574cd696483228d57eb623ff19ba5