### PR TITLE
Handle prompt load errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import os
 from datetime import datetime
 import argparse
 from dotenv import load_dotenv
+import sys
 
 
 class LLMServerUnavailable(Exception):
@@ -25,6 +26,23 @@ def parse_env():
     server = os.getenv("SERVER", DEFAULT_SERVER)
     model = os.getenv("MODEL", DEFAULT_MODEL)
     return server, model
+
+
+def load_prompt_data(path="prompt.json"):
+    """Load prompt configuration from JSON file.
+
+    If the file is missing or contains invalid JSON, print a user friendly
+    error message and exit with a non-zero code.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        print(f"Error: prompt file '{path}' not found.")
+    except json.JSONDecodeError as exc:
+        print(f"Error: could not parse '{path}': {exc}")
+
+    sys.exit(1)
 
 def ask_llm(prompt, server_url, model):
     """Send prompt to the local LLM server and return its response.
@@ -134,8 +152,7 @@ def main():
             datetime.now().strftime("%Y%m%d_%H%M%S.log"),
         )
 
-    with open("prompt.json", "r", encoding="utf-8") as f:
-        prompt_data = json.load(f)
+    prompt_data = load_prompt_data("prompt.json")
     system_prompt = prompt_data["system"]
     examples = prompt_data.get("examples", [])
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,7 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, mock_open
+import io
+import json
 import requests
 
 import main
@@ -19,6 +21,23 @@ class AskLLMTests(unittest.TestCase):
 class CheckCommandErrorTests(unittest.TestCase):
     def test_case_insensitive(self):
         self.assertTrue(check_command_error("SyNtAx ErRoR somewhere"))
+
+
+class LoadPromptDataTests(unittest.TestCase):
+    @patch("builtins.open", side_effect=FileNotFoundError)
+    @patch("sys.exit")
+    def test_file_not_found_exits(self, mock_exit, mock_open_fn):
+        main.load_prompt_data("missing.json")
+        mock_exit.assert_called_once()
+        self.assertNotEqual(mock_exit.call_args[0][0], 0)
+
+    @patch("json.load", side_effect=json.JSONDecodeError("msg", "doc", 0))
+    @patch("builtins.open", new_callable=mock_open, read_data="{}")
+    @patch("sys.exit")
+    def test_json_error_exits(self, mock_exit, mock_open_fn, mock_json):
+        main.load_prompt_data("bad.json")
+        mock_exit.assert_called_once()
+        self.assertNotEqual(mock_exit.call_args[0][0], 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- exit cleanly if `prompt.json` is missing or malformed
- add tests for prompt loading failure cases

## Testing
- `python -m pytest -q`