### PR TITLE
Add timeout to ask_llm requests

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,8 +26,19 @@ def parse_env():
     model = os.getenv("MODEL", DEFAULT_MODEL)
     return server, model
 
-def ask_llm(prompt, server_url, model):
+def ask_llm(prompt, server_url, model, timeout=30):
     """Send prompt to the local LLM server and return its response.
+
+    Parameters
+    ----------
+    prompt : str
+        Prompt to send to the model.
+    server_url : str
+        Base URL of the LLM server.
+    model : str
+        Target model name.
+    timeout : int or float, optional
+        Timeout in seconds for the HTTP request. Defaults to ``30``.
 
     Raises
     ------
@@ -43,6 +54,7 @@ def ask_llm(prompt, server_url, model):
                 "prompt": prompt,
                 "stream": False,
             },
+            timeout=timeout,
         )
         res.raise_for_status()
     except req_exc.RequestException as exc:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,6 +15,21 @@ class AskLLMTests(unittest.TestCase):
         with self.assertRaises(LLMServerUnavailable):
             ask_llm("hi", "http://localhost", "model")
 
+    @patch("requests.post")
+    def test_timeout_passed_to_requests(self, mock_post):
+        mock_response = unittest.mock.Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"response": "ok"}
+        mock_post.return_value = mock_response
+
+        ask_llm("hi", "http://localhost", "model", timeout=5)
+
+        mock_post.assert_called_with(
+            "http://localhost/api/generate",
+            json={"model": "model", "prompt": "hi", "stream": False},
+            timeout=5,
+        )
+
 
 class CheckCommandErrorTests(unittest.TestCase):
     def test_case_insensitive(self):


### PR DESCRIPTION
## Summary
- allow setting a timeout when calling `ask_llm`
- pass the timeout to `requests.post`
- test that the timeout argument is used

## Testing
- `python -m pytest -q`