### PR TITLE
Add prompt and response logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ python main.py
 
 The default server is `http://localhost:11434` and the default model is `qwen3:4b` if the variables are not set.
 
+By default all commands, prompts and responses are logged to a timestamped file under the `logs/` directory. You can override the location with the `--log-file` argument.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/main.py
+++ b/main.py
@@ -98,6 +98,15 @@ def log_step(cmd, out, err):
             f.write(f"stderr:\n{err}\n")
         f.write("\n")
 
+def log_interaction(prompt, response):
+    """Log a prompt and the LLM's response with timestamp."""
+    if not LOG_FILE:
+        return
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    with open(LOG_FILE, "a", encoding="utf-8") as f:
+        f.write(f"[{timestamp}] Prompt:\n{prompt}\n")
+        f.write(f"Response:\n{response}\n\n")
+
 def check_command_error(err):
     lower_err = err.lower()
     error_signatures = [
@@ -165,6 +174,7 @@ def main():
                         continue
                     print("Остановка задачи.")
                     return
+            log_interaction(prompt, response)
 
             commands = re.findall(r"COMMAND:\s*(.+)", response)
 


### PR DESCRIPTION
## Summary
- log prompts and LLM responses with timestamps
- store the extended logs before parsing commands
- document logging behaviour in README

## Testing
- `python -m pip install -r requirements.txt`
- `python -m unittest tests/test_main.py -v`


------
https://chatgpt.com/codex/tasks/task_e_6885785ac4e0832297867640e11f8df2