### PR TITLE
Implement AUTO_CONFIRM environment support

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,7 +28,8 @@ LOG_FILE = None
 def parse_env():
     server = os.getenv("SERVER", DEFAULT_SERVER)
     model = os.getenv("MODEL", DEFAULT_MODEL)
-    return server, model
+    auto = os.getenv("AUTO_CONFIRM", "").lower() in {"1", "true", "yes", "y"}
+    return server, model, auto
 
 def load_prompt_data(path="prompt.json"):
     """Load prompt configuration from JSON file.
@@ -179,7 +180,7 @@ def main():
     system_prompt = prompt_data["system"]
     examples = prompt_data.get("examples", [])
 
-    server_url, model = parse_env()
+    server_url, model, auto_confirm = parse_env()
 
     while True:
         task = input("\nЧто нужно сделать?\n")
@@ -217,7 +218,10 @@ def main():
                 step_count += 1
                 print(f"\n[Step {step_count}]\nCommand {idx}: {cmd}")
 
-                confirm = input("Выполнить? (y/n/q): ")
+                if auto_confirm:
+                    confirm = "y"
+                else:
+                    confirm = input("Выполнить? (y/n/q): ")
                 if confirm.lower() == "q":
                     print("Остановка задачи.")
                     return

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, mock_open
 import io
 import json
 import requests
+import os
 
 import main
 from main import ask_llm, LLMServerUnavailable, check_command_error
@@ -53,6 +54,27 @@ class LoadPromptDataTests(unittest.TestCase):
         main.load_prompt_data("bad.json")
         mock_exit.assert_called_once()
         self.assertNotEqual(mock_exit.call_args[0][0], 0)
+
+
+class ParseEnvTests(unittest.TestCase):
+    @patch.dict(os.environ, {}, clear=True)
+    def test_defaults(self):
+        server, model, auto = main.parse_env()
+        self.assertEqual(server, main.DEFAULT_SERVER)
+        self.assertEqual(model, main.DEFAULT_MODEL)
+        self.assertFalse(auto)
+
+    @patch.dict(os.environ, {"SERVER": "s", "MODEL": "m", "AUTO_CONFIRM": "true"}, clear=True)
+    def test_custom(self):
+        server, model, auto = main.parse_env()
+        self.assertEqual(server, "s")
+        self.assertEqual(model, "m")
+        self.assertTrue(auto)
+
+    @patch.dict(os.environ, {"AUTO_CONFIRM": "no"}, clear=True)
+    def test_false(self):
+        _, _, auto = main.parse_env()
+        self.assertFalse(auto)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- parse `AUTO_CONFIRM` in environment variables and skip prompts when enabled
- update main loop to accept the new flag
- test `parse_env` handling of the new variable

## Testing
- `python -m pytest -q`