### PR TITLE
Track command exit codes and print summary

### DIFF
--- a/main.py
+++ b/main.py
@@ -129,7 +129,7 @@ def run_command(cmd):
     if err:
         print("stderr:", err)
 
-    return out, err
+    return out, err, result.returncode
 
 def log_step(cmd, out, err):
     if not LOG_FILE:
@@ -203,6 +203,8 @@ def main():
     system_prompt = prompt_data["system"]
     examples = prompt_data.get("examples", [])
 
+    executed = []
+
     server_url, model, auto_confirm = parse_env()
 
     # Ensure the LLM server is up before starting the interactive loop
@@ -264,7 +266,8 @@ def main():
                 if not is_safe:
                     print("⚠️  Выполняется потенциально опасная команда.")
 
-                out, err = run_command(cmd)
+                out, err, code = run_command(cmd)
+                executed.append((cmd, code))
                 log_step(cmd, out, err)
 
                 if err and check_command_error(err):
@@ -274,6 +277,11 @@ def main():
 
                 output_text = f"stdout:\n{out}\nstderr:\n{err}"
                 history.append({"role": "system", "content": output_text})
+
+    if executed:
+        print("\nExecuted commands summary:")
+        for i, (cmd, code) in enumerate(executed, 1):
+            print(f"{i}. {cmd} (exit code: {code})")
 
 if __name__ == "__main__":
     main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -107,7 +107,8 @@ class MainExecutionSafetyTests(unittest.TestCase):
              patch.object(main, "load_prompt_data", return_value={"system": "", "examples": []}), \
              patch.object(main, "ask_llm", side_effect=fake_ask_llm), \
              patch.object(main, "is_command_safe", return_value=safe), \
-             patch.object(main, "run_command", return_value=("", "")) as run_mock:
+             patch.object(main, "run_command", return_value=("", "", 0)) as run_mock, \
+             patch.object(main, "check_llm_server", return_value=None):
             main_entry()
             return run_mock.called
 


### PR DESCRIPTION
## Summary
- include the exit status in `run_command`
- track each executed command inside `main`
- display a numbered summary of executed commands at the end
- adjust tests for new behaviour

## Testing
- `python -m pytest -q`