### PR TITLE
Add CI workflow for Python tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,29 @@
+name: Python tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Run tests
+        run: |
+          python -m unittest discover -s tests -v

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ By default all commands, prompts and responses are logged to a timestamped file 
 
 Set `AUTO_CONFIRM` to `true` in the environment to run safe commands without confirmation. Dangerous commands are always confirmed explicitly.
 
+## Running tests
+
+Install the dependencies and run:
+
+```bash
+python -m unittest discover
+```
+
+All tests are executed automatically on GitHub for every push and pull request.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- run unit tests in GitHub Actions
- document how to run the test suite

## Testing
- `python -m unittest discover -s tests -v`